### PR TITLE
bump all deps, migrate to scala 2.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        java: [11, 17, 21]
+        java: [17, 21, 25]
         platform: [ubuntu-24.04]
 
     steps:
@@ -39,4 +39,4 @@ jobs:
       uses: sbt/setup-sbt@v1
 
     - name: Run tests
-      run: sbt test
+      run: sbt -mem 3000 +test

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
 style       = defaultWithAlign
 maxColumn   = 120
-version = 3.7.2
-runner.dialect = scala212
+version = 3.11.5
+runner.dialect = scala213

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ human-friendly API. Currently, is under an active development.
 
 ## Installation
 
-libLTR is published to maven-central for scala 3.x, 2.12 and 2.13, so for SBT, add this snippet to `build.sbt`:
+libLTR is published to maven-central for scala 3.x and 2.13, so for SBT, add this snippet to `build.sbt`:
 ```scala
 libraryDependencies += "io.github.metarank" %% "ltrlib" % "0.2.2"
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ name := "ltrlib"
 
 version := "0.2.6"
 
-scalaVersion := "2.13.14"
+scalaVersion := "2.13.18"
 
-crossScalaVersions := List("2.13.14", "2.12.19", "3.4.1")
+crossScalaVersions := List("2.13.18", "3.9.0")
 
 organization := "io.github.metarank"
 
@@ -14,42 +14,47 @@ Test / logBuffered := false
 
 Test / parallelExecution := false
 
-scalacOptions ++= Seq("-feature", "-deprecation", "-release:8")
+scalacOptions ++= Seq("-feature", "-deprecation", "-release:17")
+
+javacOptions ++= Seq("--release", "17")
 
 libraryDependencies ++= Seq(
-  "org.scalatest"          %% "scalatest"               % scalatestVersion % Test,
-  "org.scalatest"          %% "scalatest-propspec"      % scalatestVersion % Test,
-  "org.scalactic"          %% "scalactic"               % scalatestVersion % Test,
-  "org.scalatestplus"      %% "scalacheck-1-16"         % "3.2.14.0"       % Test,
-  "com.github.pathikrit"   %% "better-files"            % "3.9.2",
-  "org.slf4j"               % "slf4j-api"               % slf4jversion,
-  "org.slf4j"               % "slf4j-simple"            % slf4jversion     % Test,
-  "org.apache.commons"      % "commons-math3"           % "3.6.1",
-  "io.github.metarank"     %% "cfor"                    % "0.3",
-  "io.github.metarank"      % "lightgbm4j"              % "4.4.0-1",
-  "io.github.metarank"      % "xgboost-java"            % "2.0.2-1",
-  "com.opencsv"             % "opencsv"                 % "5.9",
-  "org.scala-lang.modules" %% "scala-collection-compat" % "2.12.0",
-  "io.github.metarank"      % "catboost-train-java"     % "1.2.2-1",
-  "ai.catboost"             % "catboost-prediction"     % "1.2.5",
-  "it.unimi.dsi"            % "fastutil"                % "8.5.13"
+  "org.scalatest"        %% "scalatest"           % scalatestVersion % Test,
+  "org.scalatest"        %% "scalatest-propspec"  % scalatestVersion % Test,
+  "org.scalactic"        %% "scalactic"           % scalatestVersion % Test,
+  "org.scalatestplus"    %% "scalacheck-1-19"     % "3.2.20.0"       % Test,
+  "com.github.pathikrit" %% "better-files"        % "3.9.2",
+  "org.slf4j"             % "slf4j-api"           % slf4jversion,
+  "org.slf4j"             % "slf4j-simple"        % slf4jversion     % Test,
+  "org.apache.commons"    % "commons-math3"       % "3.6.1",
+  "io.github.metarank"   %% "cfor"                % "0.3",
+  "io.github.metarank"    % "lightgbm4j"          % "4.6.0-2",
+  "io.github.metarank"    % "xgboost-java"        % "2.0.2-1",
+  "com.opencsv"           % "opencsv"             % "5.12.0",
+  "io.github.metarank"    % "catboost-train-java" % "1.2.2-1",
+  "ai.catboost"           % "catboost-prediction" % "1.2.10",
+  "it.unimi.dsi"          % "fastutil"            % "8.5.19"
 )
-
-sonatypeProfileName := "io.github.metarank"
 
 publishMavenStyle := true
 
-publishTo := sonatypePublishToBundle.value
+// sbt 2 built-in Sonatype Central Portal publishing: `+publishSigned` stages into target/sona-staging,
+// then `sonaRelease` uploads and releases. Credentials via SONATYPE_USERNAME / SONATYPE_PASSWORD
+// (Central Portal user token) or a Credentials entry for host central.sonatype.com.
+publishTo := {
+  val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
+  if (isSnapshot.value) Some("central-snapshots" at centralSnapshots) else localStaging.value
+}
 
-licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+licenses := Seq("APL2" -> uri("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 
-homepage := Some(url("https://github.com/metarank/ltrlib"))
+homepage := Some(uri("https://github.com/metarank/ltrlib"))
 scmInfo := Some(
   ScmInfo(
-    url("https://github.com/metarank/ltrlib"),
+    uri("https://github.com/metarank/ltrlib"),
     "scm:git@github.com:metarank/ltrlib.git"
   )
 )
 developers := List(
-  Developer(id = "romangrebennikov", name = "Roman Grebennikov", email = "grv@dfdx.me", url = url("https://dfdx.me/"))
+  Developer(id = "romangrebennikov", name = "Roman Grebennikov", email = "grv@dfdx.me", url = uri("https://dfdx.me/"))
 )

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,9 @@ Test / logBuffered := false
 
 Test / parallelExecution := false
 
+// lightgbm4j JNI lib can be loaded only once per JVM, so +test needs a fresh JVM per Scala version
+Test / fork := true
+
 scalacOptions ++= Seq("-feature", "-deprecation", "-release:17")
 
 javacOptions ++= Seq("--release", "17")

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -1,6 +1,4 @@
 object Deps {
-  lazy val scalatestVersion = "3.2.19"
-  lazy val ejmlVersion      = "0.40"
-  lazy val slf4jversion     = "2.0.13"
-  lazy val circeVersion     = "0.14.3"
+  lazy val scalatestVersion = "3.2.20"
+  lazy val slf4jversion     = "2.0.19"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.0
+sbt.version = 2.0.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("com.timushev.sbt" % "sbt-updates"  % "0.6.4")
-addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype" % "3.11.0")
-addSbtPlugin("com.github.sbt"   % "sbt-pgp"      % "2.2.1")
-addSbtPlugin("org.scalameta"    % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates"  % "0.7.0")
+addSbtPlugin("com.github.sbt"   % "sbt-pgp"      % "2.3.2")
+addSbtPlugin("org.scalameta"    % "sbt-scalafmt" % "2.6.2")

--- a/src/main/scala/io/github/metarank/ltrlib/booster/XGBoostBooster.scala
+++ b/src/main/scala/io/github/metarank/ltrlib/booster/XGBoostBooster.scala
@@ -50,7 +50,7 @@ case class XGBoostBooster(
   override def weights(): Array[Double] = whenNotClosed {
     val names   = (0 until model.getNumFeature.toInt).map(i => s"feature$i").toArray
     val weights = model.getFeatureScore(names).asScala
-    val result = for {
+    val result  = for {
       name <- names
     } yield {
       weights.get(name).map(_.doubleValue()).getOrElse(0.0)

--- a/src/main/scala/io/github/metarank/ltrlib/input/CSVInputFormat.scala
+++ b/src/main/scala/io/github/metarank/ltrlib/input/CSVInputFormat.scala
@@ -45,7 +45,7 @@ object CSVInputFormat extends InputFormat {
   ): Either[DatasetError, List[LabeledItem]] = for {
     labelCol <- header.get(labelColumn).toRight(DatasetError(s"label column $labelColumn not found in header"))
     groupCol <- header.get(groupColumn).toRight(DatasetError(s"group column $groupColumn not found in header"))
-    rows <- Try(reader.iterator().asScala.toList) match {
+    rows     <- Try(reader.iterator().asScala.toList) match {
       case Failure(exception) => Left(DatasetError(s"error parsing: $exception"))
       case Success(value)     => Right(value)
     }

--- a/src/main/scala/io/github/metarank/ltrlib/input/LibsvmInputFormat.scala
+++ b/src/main/scala/io/github/metarank/ltrlib/input/LibsvmInputFormat.scala
@@ -55,7 +55,7 @@ object LibsvmInputFormat extends InputFormat {
     groups.toList
   }
 
-  val queryPattern = "(qid:)?([0-9]+)".r
+  val queryPattern                                                   = "(qid:)?([0-9]+)".r
   def parseLine(dim: Int, line: String, index: Int = 0): LabeledItem = {
     val tokens = line.split(' ').takeWhile(!_.contains('#'))
     if (tokens.length < 3)
@@ -63,7 +63,7 @@ object LibsvmInputFormat extends InputFormat {
         s"LibSVM format requires at least two columns: label and qid, but got ${tokens.length} on row $index"
       )
     val label = tokens(0).toDouble
-    val qid = tokens(1) match {
+    val qid   = tokens(1) match {
       case queryPattern(_, id) => id.toInt
       case _ => throw new IllegalArgumentException(s"qid format for item '${tokens(1)}' is not supported on row $index")
     }

--- a/src/main/scala/io/github/metarank/ltrlib/model/Query.scala
+++ b/src/main/scala/io/github/metarank/ltrlib/model/Query.scala
@@ -3,10 +3,10 @@ package io.github.metarank.ltrlib.model
 import io.github.metarank.cfor._
 import org.apache.commons.math3.linear.{ArrayRealVector, RealVector}
 case class Query(group: Int, labels: Array[Double], values: Array[Double]) {
-  val memUsed                      = labels.length * 8 + values.length * 8
-  val rows                         = labels.length
-  val columns                      = values.length / labels.length
-  def getValue(row: Int, col: Int) = values(columns * row + col)
+  val memUsed                         = labels.length * 8 + values.length * 8
+  val rows                            = labels.length
+  val columns                         = values.length / labels.length
+  def getValue(row: Int, col: Int)    = values(columns * row + col)
   def getRow(row: Int): Array[Double] = {
     val result = new Array[Double](columns)
     cfor(0 until columns) { col => result(col) = values(row * columns + col) }

--- a/src/main/scala/io/github/metarank/ltrlib/ranking/pairwise/LambdaMART.scala
+++ b/src/main/scala/io/github/metarank/ltrlib/ranking/pairwise/LambdaMART.scala
@@ -38,7 +38,7 @@ object LambdaMART {
       case Feature.VectorFeature(name, size) => (0 until size).map(i => s"${name}_$i")
     }
     val trainDs = FlattenedDataset(dataset)
-    val train =
+    val train   =
       BoosterDataset(
         dataset,
         trainDs.featureValues,
@@ -50,7 +50,7 @@ object LambdaMART {
         featureNames.toArray
       )
     val trainDatasetNative = booster.formatData(train, None, options)
-    val testDatasetNative = for {
+    val testDatasetNative  = for {
       testDataset <- testDatasetOption
       testDs = FlattenedDataset.apply(testDataset)
     } yield {

--- a/src/main/scala/io/github/metarank/ltrlib/ranking/pointwise/LogRegRanker.scala
+++ b/src/main/scala/io/github/metarank/ltrlib/ranking/pointwise/LogRegRanker.scala
@@ -145,7 +145,7 @@ object LogRegRanker {
   case class SingularFeatureWeight(feature: SingularFeature, weight: Double)     extends FeatureWeight
   case class CategoryFeatureWeight(feature: CategoryFeature, weight: Double)     extends FeatureWeight
   case class VectorFeatureWeight(feature: VectorFeature, weights: Array[Double]) extends FeatureWeight
-  case class LogRegModel(weights: List[FeatureWeight], intercept: Double) extends Model {
+  case class LogRegModel(weights: List[FeatureWeight], intercept: Double)        extends Model {
     val weightsVector = new ArrayRealVector(weights.flatMap {
       case SingularFeatureWeight(_, weight) => List(weight)
       case CategoryFeatureWeight(_, weight) => List(weight)
@@ -153,7 +153,7 @@ object LogRegRanker {
     }.toArray)
 
     override def eval(data: Dataset, metric: Metric): Double = {
-      val y = data.groups.map(_.labels)
+      val y    = data.groups.map(_.labels)
       val yhat = for {
         group <- data.groups
       } yield {

--- a/src/test/scala/io/github/metarank/ltrlib/dataset/LinearDataset.scala
+++ b/src/test/scala/io/github/metarank/ltrlib/dataset/LinearDataset.scala
@@ -4,7 +4,7 @@ import io.github.metarank.ltrlib.model.Feature.SingularFeature
 import io.github.metarank.ltrlib.model.{Dataset, DatasetDescriptor, LabeledItem, Query}
 
 object LinearDataset {
-  val desc = DatasetDescriptor(List(SingularFeature("one"), SingularFeature("two")))
+  val desc    = DatasetDescriptor(List(SingularFeature("one"), SingularFeature("two")))
   def apply() = Dataset(
     desc,
     List(

--- a/src/test/scala/io/github/metarank/ltrlib/dataset/SmallDiabetesDataset.scala
+++ b/src/test/scala/io/github/metarank/ltrlib/dataset/SmallDiabetesDataset.scala
@@ -4,7 +4,7 @@ import io.github.metarank.ltrlib.model.Feature.SingularFeature
 import io.github.metarank.ltrlib.model.{Dataset, DatasetDescriptor, LabeledItem, Query}
 
 object SmallDiabetesDataset {
-  val desc = DatasetDescriptor(List(SingularFeature("one"), SingularFeature("two")))
+  val desc    = DatasetDescriptor(List(SingularFeature("one"), SingularFeature("two")))
   def apply() = Dataset(
     desc,
     List(

--- a/src/test/scala/io/github/metarank/ltrlib/metric/NDCGTest.scala
+++ b/src/test/scala/io/github/metarank/ltrlib/metric/NDCGTest.scala
@@ -95,9 +95,9 @@ class NDCGTest extends AnyFlatSpec with Matchers {
   }
 
   it should "fuzzer: match xgboost implementation" in {
-    val train = (0 until 1000).map(i => makeQuery(i, 2 + Random.nextInt(20), 10)).toList
-    val desc  = DatasetDescriptor((0 until 10).map(i => SingularFeature(s"f$i")).toList)
-    val opts  = XGBoostOptions(treeMethod = "hist", randomSeed = 0)
+    val train   = (0 until 1000).map(i => makeQuery(i, 2 + Random.nextInt(20), 10)).toList
+    val desc    = DatasetDescriptor((0 until 10).map(i => SingularFeature(s"f$i")).toList)
+    val opts    = XGBoostOptions(treeMethod = "hist", randomSeed = 0)
     val booster =
       XGBoostBooster.train(
         XGBoostBooster.formatData(dswrap(train, desc), None, XGBoostOptions()),
@@ -128,8 +128,8 @@ class NDCGTest extends AnyFlatSpec with Matchers {
   )
 
   def dswrap(q: List[Query], desc: DatasetDescriptor) = {
-    val dataset = Dataset(desc, q)
-    val trainDs = FlattenedDataset(dataset)
+    val dataset      = Dataset(desc, q)
+    val trainDs      = FlattenedDataset(dataset)
     val featureNames = dataset.desc.features.flatMap {
       case Feature.SingularFeature(name)     => List(name)
       case Feature.CategoryFeature(name)     => List(name)

--- a/src/test/scala/io/github/metarank/ltrlib/output/LibSVMOutputFormatTest.scala
+++ b/src/test/scala/io/github/metarank/ltrlib/output/LibSVMOutputFormatTest.scala
@@ -10,7 +10,7 @@ import scala.collection.immutable.List
 
 class LibSVMOutputFormatTest extends AnyFlatSpec with Matchers {
   val desc = DatasetDescriptor(List(SingularFeature("f1"), SingularFeature("f2")))
-  val ds = Dataset(
+  val ds   = Dataset(
     desc,
     List(
       Query(desc, List(LabeledItem(1, 1, Array(1.0, 2.0)), LabeledItem(0, 1, Array(0.0, 0.0)))),

--- a/src/test/scala/io/github/metarank/ltrlib/ranking/pairwise/LambdaMARTMissingTest.scala
+++ b/src/test/scala/io/github/metarank/ltrlib/ranking/pairwise/LambdaMARTMissingTest.scala
@@ -24,7 +24,7 @@ class LambdaMARTMissingTest extends AnyFlatSpec with Matchers {
   }
 
   it should "train on letor: xgboost" in {
-    val opts = XGBoostOptions()
+    val opts    = XGBoostOptions()
     val lm      = LambdaMART(train, XGBoostBooster, Some(test), opts)
     val booster = lm.fit(opts)
     val err     = booster.eval(test, NDCG(10))

--- a/src/test/scala/io/github/metarank/ltrlib/ranking/pairwise/LambdaMARTTest.scala
+++ b/src/test/scala/io/github/metarank/ltrlib/ranking/pairwise/LambdaMARTTest.scala
@@ -19,7 +19,7 @@ import org.scalatest.matchers.should.Matchers
 class LambdaMARTTest extends AnyFlatSpec with Matchers {
   it should "train on letor: lightgbm" in {
     val opts = LightGBMOptions(earlyStopping = Some(20))
-    val lm = LambdaMART(
+    val lm   = LambdaMART(
       LetorDataset.train,
       LightGBMBooster,
       Some(LetorDataset.test),
@@ -49,7 +49,7 @@ class LambdaMARTTest extends AnyFlatSpec with Matchers {
 
   it should "train on letor: catboost" in {
     val opts = CatboostOptions(earlyStopping = Some(10))
-    val lm = LambdaMART(
+    val lm   = LambdaMART(
       LetorDataset.train,
       CatboostBooster,
       Some(LetorDataset.test),

--- a/src/test/scala/io/github/metarank/ltrlib/ranking/pointwise/LogRegRankerTest.scala
+++ b/src/test/scala/io/github/metarank/ltrlib/ranking/pointwise/LogRegRankerTest.scala
@@ -16,7 +16,7 @@ class LogRegRankerTest extends AnyFlatSpec with Matchers {
     val model = LogRegRanker(LetorDataset.train).fit(BatchSGD(30, 20, 0.3))
     model.weights.nonEmpty shouldBe true
     val errTest = model.eval(LetorDataset.test, NDCG(100))
-    val errRand = RandomRanker().fit().eval(LetorDataset.test, NDCG(100))
+    val errRand = RandomRanker().fit(()).eval(LetorDataset.test, NDCG(100))
     errTest should be > errRand
   }
 
@@ -43,7 +43,7 @@ class LogRegRankerTest extends AnyFlatSpec with Matchers {
   }
 
   it should "not fail on correlated features" in {
-    val desc = DatasetDescriptor(List(SingularFeature("one"), SingularFeature("two")))
+    val desc    = DatasetDescriptor(List(SingularFeature("one"), SingularFeature("two")))
     val dataset = Dataset(
       desc,
       List(


### PR DESCRIPTION
## Build & CI refresh: sbt 2, Scala 2.13.18/3.9, deps bump

  The build was frozen at mid-2024 (sbt 1.10, Scala 2.13.14/3.4.1, GHA on ubuntu-20.04 with node16 actions), and a couple of things had quietly rotted underneath it. This PR bumps everything in one go instead of a scala-steward drip.

  ### What changed and why
                                                                                                                                                                                                             
  - **CI**: ubuntu-20.04 is retired and `checkout@v2` / `setup-java@v1` / `cache@v2` are deprecated. Moved to ubuntu-24.04 with current action versions, mirroring metarank. sbt is no longer preinstalled on 24.04 images, so `sbt/setup-sbt` is now explicit. The cache step was also broken: single-line `path` and a key hashing `pom.xml`, which does not exist here.
  - **sbt 2.0.8**: same as metarank. The real consequence is publishing: `sbt-sonatype` has no sbt 2 release, and the OSSRH endpoint it targeted was shut down in mid-2025 anyway. Replaced with sbt's built-in Central Portal publishing (`+publishSigned` then `sonaRelease`). Credentials now come from `SONATYPE_USERNAME`/`SONATYPE_PASSWORD` or a `Credentials` entry for `central.sonatype.com`.
  - **Scala 2.12 dropped**, cross-build is 2.13.18 + 3.9.0. Nothing in the code used `scala-collection-compat`, so it's gone too.
  - **JDK target 8 -> 17**, CI matrix 17/21/25. Java 8 as a target made no sense with sbt 2 requiring 17 to run the build.
  - **Deps**: lightgbm4j 4.6.0-2, catboost-prediction 1.2.10, scalatest 3.2.20, scalacheck-1-19, slf4j 2.0.19, opencsv 5.12, fastutil 8.5.19. scalafmt 3.11.5 reformatted a dozen files, whitespace only.

  ### Gotchas

  - Scala 3.9 no longer inserts `()` for a `Unit` parameter, so one test call became `fit(())`. No API change.
  - `sbt 2` reads `~/.sbt/2.0/`, not `~/.sbt/1.0/`, so local publishing creds need to move before the next release.

  Tests pass on both Scala versions, `+publishLocal` works.
