### PR TITLE
Migrate to Scala 3 only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
       uses: sbt/setup-sbt@v1
 
     - name: Run tests
-      run: sbt -mem 3000 +test
+      run: sbt -mem 3000 test

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
 style       = defaultWithAlign
 maxColumn   = 120
 version = 3.11.5
-runner.dialect = scala213
+runner.dialect = scala3

--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ human-friendly API. Currently, is under an active development.
 
 ## Installation
 
-libLTR is published to maven-central for scala 3.x and 2.13, so for SBT, add this snippet to `build.sbt`:
+libLTR is published to maven-central for scala 3.x, so for SBT, add this snippet to `build.sbt`:
 ```scala
-libraryDependencies += "io.github.metarank" %% "ltrlib" % "0.2.2"
+libraryDependencies += "io.github.metarank" %% "ltrlib" % "0.2.6"
 ```
 
 For maven:
 ```xml
 <dependency>
   <groupId>io.github.metarank</groupId>
-  <artifactId>ltrlib_2.13</artifactId>
-  <version>0.2.2</version>
+  <artifactId>ltrlib_3</artifactId>
+  <version>0.2.6</version>
 </dependency>
 ```
 ## Usage

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,7 @@ name := "ltrlib"
 
 version := "0.2.6"
 
-scalaVersion := "2.13.18"
-
-crossScalaVersions := List("2.13.18", "3.9.0")
+scalaVersion := "3.9.0"
 
 organization := "io.github.metarank"
 
@@ -14,7 +12,7 @@ Test / logBuffered := false
 
 Test / parallelExecution := false
 
-// lightgbm4j JNI lib can be loaded only once per JVM, so +test needs a fresh JVM per Scala version
+// lightgbm4j JNI lib can be loaded only once per JVM, so tests run in a fresh forked JVM
 Test / fork := true
 
 scalacOptions ++= Seq("-feature", "-deprecation", "-release:17")
@@ -23,9 +21,7 @@ javacOptions ++= Seq("--release", "17")
 
 libraryDependencies ++= Seq(
   "org.scalatest"        %% "scalatest"           % scalatestVersion % Test,
-  "org.scalatest"        %% "scalatest-propspec"  % scalatestVersion % Test,
   "org.scalactic"        %% "scalactic"           % scalatestVersion % Test,
-  "org.scalatestplus"    %% "scalacheck-1-19"     % "3.2.20.0"       % Test,
   "com.github.pathikrit" %% "better-files"        % "3.9.2",
   "org.slf4j"             % "slf4j-api"           % slf4jversion,
   "org.slf4j"             % "slf4j-simple"        % slf4jversion     % Test,
@@ -41,7 +37,7 @@ libraryDependencies ++= Seq(
 
 publishMavenStyle := true
 
-// sbt 2 built-in Sonatype Central Portal publishing: `+publishSigned` stages into target/sona-staging,
+// sbt 2 built-in Sonatype Central Portal publishing: `publishSigned` stages into target/sona-staging,
 // then `sonaRelease` uploads and releases. Credentials via SONATYPE_USERNAME / SONATYPE_PASSWORD
 // (Central Portal user token) or a Credentials entry for host central.sonatype.com.
 publishTo := {

--- a/src/main/scala/io/github/metarank/ltrlib/input/CSVInputFormat.scala
+++ b/src/main/scala/io/github/metarank/ltrlib/input/CSVInputFormat.scala
@@ -5,7 +5,7 @@ import io.github.metarank.ltrlib.input.InputFormat.DatasetError
 import io.github.metarank.ltrlib.model.Feature.SingularFeature
 import io.github.metarank.ltrlib.model.{DatasetDescriptor, LabeledItem, Query}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import java.io.{InputStream, InputStreamReader}
 import scala.util.{Failure, Success, Try}
 

--- a/src/test/scala/io/github/metarank/ltrlib/QueryTest.scala
+++ b/src/test/scala/io/github/metarank/ltrlib/QueryTest.scala
@@ -33,7 +33,7 @@ class QueryTest extends AnyFlatSpec with Matchers {
         )
       )
     )
-    result shouldBe a[Failure[_]]
+    result shouldBe a[Failure[?]]
   }
 
 }

--- a/src/test/scala/io/github/metarank/ltrlib/input/CSVInputFormatTest.scala
+++ b/src/test/scala/io/github/metarank/ltrlib/input/CSVInputFormatTest.scala
@@ -12,7 +12,7 @@ class CSVInputFormatTest extends AnyFlatSpec with Matchers {
       """group,label,f1,f2
         |1,1,0,0
         |1,0,0,0""".stripMargin
-    val result = CSVInputFormat.load("group", "label", new ByteArrayInputStream(data.getBytes)).right.get
+    val result = CSVInputFormat.load("group", "label", new ByteArrayInputStream(data.getBytes)).toOption.get
     result.desc.features shouldBe List(SingularFeature("f1"), SingularFeature("f2"))
     result.queries.size shouldBe 1
   }

--- a/src/test/scala/io/github/metarank/ltrlib/model/DatasetDescriptorTest.scala
+++ b/src/test/scala/io/github/metarank/ltrlib/model/DatasetDescriptorTest.scala
@@ -29,6 +29,6 @@ class DatasetDescriptorTest extends AnyFlatSpec with Matchers {
       SingularFeature("one"),
       VectorFeature("one", 10)
     )
-    Try(DatasetDescriptor(features)) shouldBe a[Failure[_]]
+    Try(DatasetDescriptor(features)) shouldBe a[Failure[?]]
   }
 }


### PR DESCRIPTION
Drops the Scala 2.13 cross-build; the library now compiles only for Scala 3.9.0.

- `build.sbt`: single `scalaVersion := "3.9.0"`, no `crossScalaVersions`; removed unused `scalatest-propspec` / `scalacheck-1-19` test deps
- `.scalafmt.conf`: `runner.dialect = scala3`
- CI: `sbt test` instead of `+test`
- Source: `JavaConverters` → `scala.jdk.CollectionConverters`, `Either.right.get` → `toOption.get`, `Failure[_]` → `Failure[?]`
- README: install snippet points at `ltrlib_3`

`sbt testFull` locally: 14 suites, 55 tests, all green on JDK 21.

Version left at 0.2.6; dropping 2.13 is publishing-visible, so a 0.3.0 bump may be warranted before release.